### PR TITLE
new "skip" option (inspired by react integration) ... and details

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const apolloClient = new ApolloClient({
   queryTransformer: addTypename,
 });
 
-//create a new polymer behavior from PolymerApollo class. 
+//create a new polymer behavior from PolymerApollo class.
 export const PolymerApolloBehavior = new PolymerApollo({apolloClient})
 ```
 
@@ -131,7 +131,7 @@ You can then use your property as usual in your polymer component:
 
 You can add variables (read parameters) to your `gql` query by declaring `query` and `variables` in an object:
 
-Variable values are paths to Polymer element properties. 
+Variable values are paths to Polymer element properties.
 
 eg `variables:{limit:"route.limit"}` . In this graphql variable limit changes when the polymer property route.limit changes (similar to observer);
 
@@ -231,8 +231,9 @@ And then use it in your polymer component:
 
 These are the available advanced options you can use:
 - `error(error)` is a hook called when there are errors, `error` being an Apollo error object with either a `graphQLErrors` property or a `networkError` property.
-- `loadingKey` will update the component data property you pass as the value. You should initialize this property to `false` in properties. When the query is loading, this property will be set to `true` and as soon as it no longer is, the property will be set to `false`. 
+- `loadingKey` will update the component data property you pass as the value. You should initialize this property to `false` in properties. When the query is loading, this property will be set to `true` and as soon as it no longer is, the property will be set to `false`.
 - `watchLoading(isLoading)` is a hook called when the loading state of the query changes.
+- `skip` can be a path to a Polymer element boolean property used to set the state of the query subscribtion. Check example below.
 
 
 ```js
@@ -355,6 +356,42 @@ export const resolvers = {
     },
   },
 };
+```
+### Skip query example
+
+```js
+properties: {
+  ...
+
+  isNotAuth: {
+    type: Boolean,
+    value: true
+  }
+},
+
+...
+
+// Apollo-specific options
+apollo: {
+  // 'tags' property of your polymer element
+  tags: {
+    query: gql`query tagList {
+      tags {
+        id,
+        label
+      }
+    }`,
+    skip: 'isNotAuth', // ms
+  },
+},
+
+listeners: {
+  'auth-changed': '_onAuthChanged'
+},
+
+_onAuthChanged: function(e) {
+  this.isNotAuth = !e.detail.userid;
+},
 ```
 
 ### Mutations

--- a/src/polymer-apollo.js
+++ b/src/polymer-apollo.js
@@ -113,6 +113,7 @@ class DollarApollo {
   }
   _subscribeObservers(key,options,observer){
     const el = this.el;
+    const $apollo = this;
     let loadingKey = options.loadingKey;
     let loadingChangeCb = options.watchLoading;
     this._changeLoader(loadingKey,true,loadingChangeCb);
@@ -123,7 +124,7 @@ class DollarApollo {
       next: nextResult,
       error: catchError
     });
-    const $apollo = this;
+
     function nextResult({ data }) {
       $apollo._changeLoader(loadingKey,false,loadingChangeCb);
       $apollo._applyData(data,key);
@@ -171,6 +172,7 @@ class DollarApollo {
   }
   _refetch(key,options,variables,observer){
     const  el = this.el;
+    const $apollo = this;
     let loadingKey = options.loadingKey;
     let loadingChangeCb = options.watchLoading;
     this._changeLoader(loadingKey,true,loadingChangeCb);
@@ -180,7 +182,7 @@ class DollarApollo {
     observer.refetch(variables, {
       forceFetch: !!options.forceFetch
     }).then(nextResult,catchError);
-    const $apollo = this;
+
     function nextResult({ data }) {
       $apollo._changeLoader(loadingKey,false,loadingChangeCb);
       $apollo._applyData(data,key);
@@ -254,7 +256,7 @@ class DollarApollo {
 
     observer = this._processVariables(key,options,sub,observer);
 
-    if (options.skip) {
+    if (options.skip !== undefined) {
       let _var = options.skip;
 
       this._addPolymerObserver(el, _var, function(newSkipValue){


### PR DESCRIPTION
- Added skip options to queries to avoid automatic query subscription
This allow you to subscribe/unsubscribe an observer. For example useful to disable query fetches when your not authentified and you know the server will reject you.

- Redefined unsubscribe()  so it automatically remove subscribtion from _apolloSubscriptions array
Just a small rewriting of unsubscribe (as you did with subscribe) to clean the subscribtion array

- Return observer subscription in method _subscribeObservers()
Just because I've needed it to unsubscribe when skip option comes to true.

Hope you'll like it.
Anthony.